### PR TITLE
Easy install kuromoji 0.7.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dependency-reduced-pom.xml
 *.iml
 
 /kuromoji-*
+/lib

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target
 dependency-reduced-pom.xml
 .idea
 *.iml
+
+/kuromoji-*

--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ BoilerpipeHTMLContentHandler handler = new BoilerpipeHTMLContentHandler(new Kuro
 BoilerpipeHTMLParser parser = new BoilerpipeHTMLParser(handler);
 String boiledDocument = ArticleExtractor.INSTANCE.getText(in.getTextDocument(parser));
 ```
+
+### Kuromoji installation
+
+To install Kuromoji without depending on [http://www.atilika.org/nexus/content/repositories/atilika/](http://www.atilika.org/nexus/content/repositories/atilika/), do:
+
+```
+make -f kuromoji.mk all install
+```
+
+which will download and install JAR from [https://github.com/atilika/kuromoji/downloads](https://github.com/atilika/kuromoji/downloads).

--- a/kuromoji.mk
+++ b/kuromoji.mk
@@ -4,26 +4,32 @@ ARCHIVE_URL := https://github.com/downloads/atilika/kuromoji/$(ARCHIVE)
 ARCHIVE_DIR := kuromoji-$(VERSION)
 JAR_FILE := kuromoji-$(VERSION)/lib/kuromoji-$(VERSION).jar
 
-all: $(ARCHIVE)
+TARGET := lib/kuromoji-$(VERSION).jar
 
-$(ARCHIVE):
-	curl -L $(ARCHIVE_URL) -o $@
+all: $(TARGET)
 
-install: $(JAR_FILE)
-	mvn install:install-file \
-		-Dfile=$(JAR_FILE) \
-		-DgroupId=org.atilika.kuromoji \
-		-DartifactId=kuromoji \
-		-Dversion=$(VERSION) \
-		-Dpackaging=jar \
-		-DgeneratePom=true
+$(TARGET): $(JAR_FILE)
+	mkdir -p $(dir $@)
+	cp $< $@
 
 $(JAR_FILE): $(ARCHIVE_DIR)
 
 $(ARCHIVE_DIR): $(ARCHIVE)
 	tar xzf $<
 
+$(ARCHIVE):
+	curl -L $(ARCHIVE_URL) -o $@
+
+install: $(TARGET)
+	mvn install:install-file \
+		-Dfile=$< \
+		-DgroupId=org.atilika.kuromoji \
+		-DartifactId=kuromoji \
+		-Dversion=$(VERSION) \
+		-Dpackaging=jar \
+		-DgeneratePom=true
+
 clean:
-	rm -rf $(ARCHIVE) $(ARCHIVE_DIR)
+	rm -rf $(TARGET) $(ARCHIVE_DIR)
 
 .PHONY: all install clean

--- a/kuromoji.mk
+++ b/kuromoji.mk
@@ -1,0 +1,29 @@
+VERSION := 0.7.7
+ARCHIVE := kuromoji-$(VERSION).tar.gz
+ARCHIVE_URL := https://github.com/downloads/atilika/kuromoji/$(ARCHIVE)
+ARCHIVE_DIR := kuromoji-$(VERSION)
+JAR_FILE := kuromoji-$(VERSION)/lib/kuromoji-$(VERSION).jar
+
+all: $(ARCHIVE)
+
+$(ARCHIVE):
+	curl -L $(ARCHIVE_URL) -o $@
+
+install: $(JAR_FILE)
+	mvn install:install-file \
+		-Dfile=$(JAR_FILE) \
+		-DgroupId=org.atilika.kuromoji \
+		-DartifactId=kuromoji \
+		-Dversion=$(VERSION) \
+		-Dpackaging=jar \
+		-DgeneratePom=true
+
+$(JAR_FILE): $(ARCHIVE_DIR)
+
+$(ARCHIVE_DIR): $(ARCHIVE)
+	tar xzf $<
+
+clean:
+	rm -rf $(ARCHIVE) $(ARCHIVE_DIR)
+
+.PHONY: all install clean

--- a/kuromoji.mk
+++ b/kuromoji.mk
@@ -1,3 +1,5 @@
+MVN ?= mvn
+
 VERSION := 0.7.7
 ARCHIVE := kuromoji-$(VERSION).tar.gz
 ARCHIVE_URL := https://github.com/downloads/atilika/kuromoji/$(ARCHIVE)
@@ -21,7 +23,7 @@ $(ARCHIVE):
 	curl -L $(ARCHIVE_URL) -o $@
 
 install: $(TARGET)
-	mvn install:install-file \
+	$(MVN) install:install-file \
 		-Dfile=$< \
 		-DgroupId=org.atilika.kuromoji \
 		-DartifactId=kuromoji \


### PR DESCRIPTION
Kuromoji on atilika.org seems to be gone [missing](http://www.atilika.org/nexus/content/repositories/atilika/).

kuromoji.mk provides simple commands to download and install its JAR from Atilika's GitHub download page.